### PR TITLE
ensure only automated RFDs are being handled by node module

### DIFF
--- a/lib/BasicJavaApplicationBuilder.js
+++ b/lib/BasicJavaApplicationBuilder.js
@@ -43,7 +43,16 @@ module.exports = class {
     const rfcIssueKey = key[0]+'-'+key[1]
   
     if (changeTarget.toLowerCase() == 'master'){
-      const jiraSettings= { url: jiraUrl, username: username, password: password, rfcIssueKey:rfcIssueKey, changeBranch:changeBranch, branchName:branchName, repoName: repoName, projectName: projectName}
+      const jiraSettings= { 
+        url: jiraUrl, 
+        username: username, 
+        password: password, 
+        rfcIssueKey:rfcIssueKey, 
+        changeBranch:changeBranch, 
+        branchName:branchName, 
+        repoName: repoName, 
+        projectName: projectName
+      }
   
       // Create the jira object of the type Jira 
       const jira = new Jira(Object.assign({ phase: 'jira-update', jira: jiraSettings}))

--- a/lib/BasicJavaApplicationDeployer.js
+++ b/lib/BasicJavaApplicationDeployer.js
@@ -25,67 +25,35 @@ module.exports = class {
     const oc=new OpenShiftClientX(Object.assign({ namespace: phases[phase].namespace }, options));
     const objects = this.processTemplates(oc);
 
-    oc.applyRecommendedLabels(objects, phases[phase].name, phase, `${changeId}`, phases[phase].instance)
+     oc.applyRecommendedLabels(objects, phases[phase].name, phase, `${changeId}`, phases[phase].instance)
     oc.importImageStreams(objects, phases[phase].tag, phases.build.namespace, phases.build.tag)
-    await oc.applyAndDeploy(objects, phases[phase].instance)
-    await this.jiraTransition()
-  }
-    
-  async jiraTransition(){
-    // Jira settings
+    await oc.applyAndDeploy(objects, phases[phase].instance) 
+  
     const env = config.options.env
-    const jiraUrl = config.jiraUrl
-    const username = config.phases[env].credentials.idir.user 
-    const password = config.phases[env].credentials.idir.pass 
     
-    const changeBranch = config.options.git.branch.merge
-    
-    const key= changeBranch.split('-')
-    const rfcIssueKey = key[0]+'-'+key[1]
 
 
-    if (env.toLowerCase() != 'dev'){
+    //await this.jiraTransition()
+    if(env.toLowerCase() != 'dev' || env.toLowerCase() != 'sbox' || env.toLowerCase() != 'sandbox')
+    {
+      const jiraUrl = config.jiraUrl
+      const username = config.phases[env].credentials.idir.user 
+      const password = config.phases[env].credentials.idir.pass 
+      const changeBranch = config.options.git.branch.merge
+      const key= changeBranch.split('-')
+      const rfcIssueKey = key[0]+'-'+key[1]
 
       const jiraSettings= { 
-            url: jiraUrl, 
-            username: username, 
-            password: password, 
-            rfcIssueKey:rfcIssueKey
-      }
-      this.jiraClient = new Jira(Object.assign({ phase: 'jira-transition', jira: jiraSettings}))
-      
-      // transition RFDs/Subtasks
-      await this.transitionRfdAndSubtasksToResolved(rfcIssueKey, env);      
-    }
-  }
-
-  async transitionRfdAndSubtasksToResolved(rfcIssueKey, env) {
-
-    if(env === CONST.ENV.DLVR){
-      await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.DLVR);
-    }
-    else if(env === CONST.ENV.TEST){
-      await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.TEST);
-    }
-    else if(env === CONST.ENV.PROD){
-      await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.PROD);
-    }
-  }
-        
-  async transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, jiraTargetEnv) {
-    const onTargetEnvRfdIssueKeys = await this.jiraClient.getRfdTaskIds(rfcIssueKey, jiraTargetEnv);
-    for (let rfdIssuekey of onTargetEnvRfdIssueKeys) {
-      const rfdSubtaskInfo = await this.jiraClient.getIssueSubtasksInfo(rfdIssuekey);
-      await this.jiraClient.transition(rfdIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.SCHEDULE);
-      await this.jiraClient.transition(rfdIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.START_PROGRESS); 
-
-      for (let subTask of rfdSubtaskInfo){
-        const subtaskIssuekey = subTask.key
-        await this.jiraClient.transition(subtaskIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.START_PROGRESS); 
-        await this.jiraClient.transition(subtaskIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.RESOLVE); 
-      }
-    }
-  }
-  
+        url: jiraUrl, 
+        username: username, 
+        password: password, 
+        rfcIssueKey:rfcIssueKey
+       }
+    
+        // Create the jira object of the type Jira 
+        const jira = new Jira(Object.assign({ phase: 'jira-transition', jira: jiraSettings}))
+        jira.transitionRFDpostDeployment(env)
+    }   
+  }    
 }
 

--- a/lib/BasicJavaApplicationDeployer.js
+++ b/lib/BasicJavaApplicationDeployer.js
@@ -34,7 +34,7 @@ module.exports = class {
 
 
     //await this.jiraTransition()
-    if(env.toLowerCase() != 'dev' || env.toLowerCase() != 'sbox' || env.toLowerCase() != 'sandbox')
+    if(env.toLowerCase() != 'dev' && env.toLowerCase() != 'sbox' && env.toLowerCase() != 'sandbox')
     {
       const jiraUrl = config.jiraUrl
       const username = config.phases[env].credentials.idir.user 

--- a/lib/Jira.js
+++ b/lib/Jira.js
@@ -40,7 +40,7 @@ class Jira {
       var containRfcToRfdLinks = 0
       var rfdIssueLinks = []
       for ( var i in rfcIssue.fields.issuelinks){
-         if(rfcIssue.fields.issuelinks[i].type.name == "RFC-RFD" && rfcIssue){
+         if(rfcIssue.fields.issuelinks[i].type.name == "RFC-RFD"){
             containRfcToRfdLinks+=1
             rfdIssueLinks.push(rfcIssue.fields.issuelinks[i].outwardIssue.key)
          }
@@ -71,10 +71,13 @@ class Jira {
       } else {
          await self._manageRfcTransitionToInitialState(this.rfcIssue);
           for ( var i in rfcIssue.fields.issuelinks){
-         if(rfcIssue.fields.issuelinks[i].type.name == "RFC-RFD" && rfcIssue){
-            await self._manageRfdAndSubtasksTransitionToInitialState(rfcIssue.fields.issuelinks[i].outwardIssue.key);
-         }
-        }
+              if(rfcIssue.fields.issuelinks[i].type.name == "RFC-RFD" ){
+                  var rfdIssueInfo = await this.getIssue(rfcIssue.fields.issuelinks[i].outwardIssue.key)
+                  if (rfdIssueInfo.fields.labels.includes("auto")){
+                   await self._manageRfdAndSubtasksTransitionToInitialState(rfcIssue.fields.issuelinks[i].outwardIssue.key);
+                  }
+               }
+          }   
       }
    }
 
@@ -313,23 +316,21 @@ class Jira {
     */
    getRfdTaskIds(rfcIssueKey, jiraTargetEnv) {
       return this.retrieveRfcIssueInfo(rfcIssueKey)
-         .then((rfcIssue) => {
-            const issuelinks = rfcIssue.fields.issuelinks;
-            if (issuelinks != undefined) {
+         .then(async (rfcIssue) => {
+            var rfcIssue = rfcIssue
                let rfdIssueKeys = [];
-               issuelinks.forEach(function(link) {
-                  if(link.outwardIssue.fields.summary.includes(jiraTargetEnv)) {
-                     rfdIssueKeys.push(link.outwardIssue.key);
+               for(var i in rfcIssue.fields.issuelinks) { 
+                  if(rfcIssue.fields.issuelinks[i].type.name == "RFC-RFD"){                  
+                     var rfdIssueInfo = await this.getIssue(rfcIssue.fields.issuelinks[i].outwardIssue.key)
+                     if(rfdIssueInfo.fields.labels.includes("auto") && rfcIssue.fields.issuelinks[i].outwardIssue.fields.summary.includes(jiraTargetEnv)) {
+                           rfdIssueKeys.push(rfcIssue.fields.issuelinks[i].outwardIssue.key);
+                         } 
+                     }
                   }
-               });
-               console.log("RFC " + rfcIssueKey + ", target env: " 
-               + jiraTargetEnv + ", contains these RFDs: " + rfdIssueKeys)
+               console.log(rfdIssueKeys)
+               console.log("RFC " + rfcIssueKey + ", target env: "+ jiraTargetEnv + ", contains these RFDs: " + rfdIssueKeys)
                return Promise.resolve(rfdIssueKeys);
-            }
-            else {
-               return Promise.resolve(undefined);
-            }
-         });
+      });
    }
 
    /**
@@ -422,6 +423,49 @@ class Jira {
       //}
 
    }
+
+   // Transition RFD post Deployment
+
+   async transitionRFDpostDeployment(env){
+      // Jira settings
+      
+      const jiraUrl = this.jiraSettings.url
+      const username = this.jiraSettings.username
+      const password = this.jiraSettings.password
+      const rfcIssueKey = this.jiraSettings.rfcIssueKey
+        
+        // transition RFDs/Subtasks
+        await this.transitionRfdAndSubtasksToResolved(rfcIssueKey, env);      
+      }
+  
+    async transitionRfdAndSubtasksToResolved(rfcIssueKey, env) {
+  
+      if(env === CONST.ENV.DLVR){
+        await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.DLVR);
+      }
+      else if(env === CONST.ENV.TEST){
+        await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.TEST);
+      }
+      else if(env === CONST.ENV.PROD){
+        await this.transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.PROD);
+      }
+    }
+          
+    async transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, jiraTargetEnv) {
+      const onTargetEnvRfdIssueKeys = await this.getRfdTaskIds(rfcIssueKey, jiraTargetEnv);
+      for (let rfdIssuekey of onTargetEnvRfdIssueKeys) {
+        const rfdSubtaskInfo = await this.getIssueSubtasksInfo(rfdIssuekey);
+        await this.transition(rfdIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.SCHEDULE);
+        await this.transition(rfdIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.START_PROGRESS); 
+  
+        for (let subTask of rfdSubtaskInfo){
+          const subtaskIssuekey = subTask.key
+          await this.transition(subtaskIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.START_PROGRESS); 
+          await this.transition(subtaskIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.RESOLVE); 
+        }
+      }
+    }
+
 } //end Jira class
 
 /**

--- a/lib/basicOracleDatabaseDeployment.js
+++ b/lib/basicOracleDatabaseDeployment.js
@@ -22,15 +22,10 @@ const CONST = require("./constants");
     const username = config.phases[env].credentials.idir.user 
     const password = config.phases[env].credentials.idir.pass 
     const changeBranch = config.options.git.branch.merge
-    const branchName = "PR-"+config.options.pr
 
     const key= changeBranch.split('-')
     const rfcIssueKey = key[0]+'-'+key[1]
 
-    const gitUrl = config.options.git.url
-    const elements = gitUrl.split('/')
-    const projectName = elements[6].toUpperCase()
-    const repoName = elements[7].split('.')[0]
 
     
     // do db migration (all env)
@@ -52,46 +47,15 @@ const CONST = require("./constants");
         }
     });
 
-    const jiraSettings= { url: jiraUrl, username: username, 
-                        password: password, 
-                        rfcIssueKey:rfcIssueKey, 
-                        changeBranch:changeBranch, 
-                        branchName:branchName, 
-                        repoName: repoName, 
-                        projectName: projectName}
-    const jiraClient = new Jira(Object.assign({ phase: 'jira-update', jira: jiraSettings}))
-
-    // transition RFDs/Subtasks
-    await transitionRfdAndSubtasksToResolved(rfcIssueKey);
-
-    async function transitionRfdAndSubtasksToResolved(rfcIssueKey) {
-        if (env === CONST.ENV.DEV || env === CONST.ENV.DLVR) {
-            await transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.DLVR);
-        }
-        else if (env === CONST.ENV.TEST) {
-            await transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.TEST);
-        }
-        else if (env === CONST.ENV.PROD) {
-            await transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, CONST.JIRA_TARGET_ENV.PROD);
-        }
-    }
-
-    async function transitionRfdAndSubtasksToResolvedOnTargetEnv(rfcIssueKey, jiraTargetEnv) {
-        const targetOnEnvRfdIssueKeys = await jiraClient.getRfdTaskIds(rfcIssueKey, jiraTargetEnv);
-        for (let rfdIssuekey of targetOnEnvRfdIssueKeys) {
-            const rfdSubtaskInfo = await jiraClient.getIssueSubtasksInfo(rfdIssuekey);
-            // TODO: verify workflow transition correctness and possible other scenarios.
-            for (let subTask of rfdSubtaskInfo){
-                await jiraClient.transition(subTask.key, CONST.ISSUE_TRANSITION_ACTION_NAME.SCHEDULE);
-            }
-            await jiraClient.transition(rfdIssuekey, CONST.ISSUE_TRANSITION_ACTION_NAME.SCHEDULE);
-            
-            for (let subTask of rfdSubtaskInfo){
-                const subtaskId = subTask.key
-                await jiraClient.transition(subtaskId, CONST.ISSUE_TRANSITION_ACTION_NAME.START_PROGRESS); 
-                await jiraClient.transition(subtaskId, CONST.ISSUE_TRANSITION_ACTION_NAME.RESOLVE); 
-            }
-        }
-    }
+    const jiraSettings= { 
+        url: jiraUrl, 
+        username: username, 
+        password: password, 
+        rfcIssueKey:rfcIssueKey
+       }
+    
+        // Create the jira object of the type Jira 
+        const jira = new Jira(Object.assign({ phase: 'jira-transition', jira: jiraSettings}))
+        jira.transitionRFDpostDeployment(env)
 
 })();

--- a/lib/basicOracleDatabaseDeployment.js
+++ b/lib/basicOracleDatabaseDeployment.js
@@ -46,7 +46,7 @@ const CONST = require("./constants");
             }
         }
     });
-    if(env.toLowerCase() != 'dev' || env.toLowerCase() != 'sbox' || env.toLowerCase() != 'sandbox')
+    if(env.toLowerCase() != 'dev' && env.toLowerCase() != 'sbox' && env.toLowerCase() != 'sandbox')
     {
     const jiraSettings= { 
         url: jiraUrl, 

--- a/lib/basicOracleDatabaseDeployment.js
+++ b/lib/basicOracleDatabaseDeployment.js
@@ -46,7 +46,8 @@ const CONST = require("./constants");
             }
         }
     });
-
+    if(env.toLowerCase() != 'dev' || env.toLowerCase() != 'sbox' || env.toLowerCase() != 'sandbox')
+    {
     const jiraSettings= { 
         url: jiraUrl, 
         username: username, 
@@ -57,5 +58,6 @@ const CONST = require("./constants");
         // Create the jira object of the type Jira 
         const jira = new Jira(Object.assign({ phase: 'jira-transition', jira: jiraSettings}))
         jira.transitionRFDpostDeployment(env)
+    }
 
 })();


### PR DESCRIPTION
Added:

None

-----------------------------------------------------------------------------------

Changed :

1)  lib/BasicJavaApplicationDeployer.js
  -> Remove code for jira transition to Resolved State implementation, add code to check for dev/sbox/sandbox where jira issues dont require to be transitioned
 
2) lib/basicOracleDatabaseDeployer.js
  -> Remove code for jira transition to Resolved State implementation,add code to check for dev/sbox/sandbox where jira issues dont require to be transitioned

3) lib/BasicJavaApplicationBuilder.js
  -> Change indentation

4) lib/Jira.js
-> Add code for transitionRFDPostDeployment
-> Modify how getRfdTasks function works so that it only manages RFC-RFD links which have the label "auto" (or which are autogenerated by the pipeline)

----------------------------------------------------------------------------------------

Deleted:

None
