### PR TITLE
Modified logic: when changeTarget is not present in user argument, wi…

### DIFF
--- a/lib/BasicJavaApplicationBuilder.js
+++ b/lib/BasicJavaApplicationBuilder.js
@@ -24,9 +24,9 @@ module.exports = class {
     const gitUrl = settings.options.git.url
     const gitElements = gitUrl.split('/')
     const repoName = gitElements[7].split('.')[0]
-  
-    const changeTarget=settings.options.git.change.target;
-    if(changeTarget.toLowerCase() == 'master') {
+    
+    let changeTarget=(settings.options.git.change != undefined)? (settings.options.git.change.target != undefined? settings.options.git.change.target : '') : '';
+    if(changeTarget && changeTarget.toLowerCase() == 'master') {
       const jiraUrl = settings.jiraUrl
       const branchName = "PR-"+settings.options.pr
 


### PR DESCRIPTION
Modified logic: when changeTarget is not present in user argument, will not call JIRA createRFD but still call Git verify and build. Also added unit tests.