### PR TITLE
Fix/createchangeset change splitstatements

### DIFF
--- a/lib/CreateChangesetUpdateChangelog.js
+++ b/lib/CreateChangesetUpdateChangelog.js
@@ -97,22 +97,21 @@ module.exports = class {
                     throw new Error('File Cannot be Appended')
                 }
             })
-            let text;
-            if(typeOfObject === 'package'){
-              text =
-                '\t<sqlFile path="../sql/' +
-                nameOfChangeSet +
-                '" splitStatements="false" relativeToChangelogFile="true"/>' +
-                '\n'
+            let text
+            if (typeOfObject === 'package') {
+                text =
+                    '\t<sqlFile path="../sql/' +
+                    nameOfChangeSet +
+                    '" splitStatements="false" relativeToChangelogFile="true"/>' +
+                    '\n'
+            } else {
+                text =
+                    '\t<sqlFile path="../sql/' +
+                    nameOfChangeSet +
+                    '" splitStatements="true" relativeToChangelogFile="true"/>' +
+                    '\n'
             }
-            else{
-              text =
-                '\t<sqlFile path="../sql/' +
-                nameOfChangeSet +
-                '" splitStatements="true" relativeToChangelogFile="true"/>' +
-                '\n'
-            }
-            
+
             fs.appendFileSync(changelogPath, text, function(err) {
                 if (err) {
                     throw new Error('File Cannot be Appended')
@@ -154,7 +153,14 @@ module.exports = class {
                         version
                     )
 
-                    const ret = self.updateChangelog(typeOfMigration, changelogPath, changesetName, username, id, typeOfObject)
+                    const ret = self.updateChangelog(
+                        typeOfMigration,
+                        changelogPath,
+                        changesetName,
+                        username,
+                        id,
+                        typeOfObject
+                    )
                     returnVal.push(ret, changesetName)
                 }
             })

--- a/lib/CreateChangesetUpdateChangelog.js
+++ b/lib/CreateChangesetUpdateChangelog.js
@@ -67,7 +67,7 @@ module.exports = class {
         }
     }
 
-    updateChangelog(typeOfMigration, changelogPath, changeset, username, id) {
+    updateChangelog(typeOfMigration, changelogPath, changeset, username, id, typeOfObject) {
         const options = {
             files: changelogPath,
             from: '</databaseChangeLog>',
@@ -97,12 +97,22 @@ module.exports = class {
                     throw new Error('File Cannot be Appended')
                 }
             })
-
-            const text =
+            let text;
+            if(typeOfObject === 'package'){
+              text =
                 '\t<sqlFile path="../sql/' +
                 nameOfChangeSet +
                 '" splitStatements="false" relativeToChangelogFile="true"/>' +
                 '\n'
+            }
+            else{
+              text =
+                '\t<sqlFile path="../sql/' +
+                nameOfChangeSet +
+                '" splitStatements="true" relativeToChangelogFile="true"/>' +
+                '\n'
+            }
+            
             fs.appendFileSync(changelogPath, text, function(err) {
                 if (err) {
                     throw new Error('File Cannot be Appended')
@@ -120,7 +130,7 @@ module.exports = class {
         }
     }
 
-    execute(typeOfMigration, schemaName, username, dbChange, migrationsDir) {
+    execute(typeOfMigration, schemaName, username, dbChange, migrationsDir, typeOfObject) {
         const changesetPath = migrationsDir + '/' + schemaName + '/' + 'sql'
         const tDate = moment.tz(Date.now(), 'America/Vancouver').format('YYYYMMDDHHmmss')
         const self = this
@@ -129,7 +139,6 @@ module.exports = class {
             const schemaFolders = fs.readdirSync(migrationsDir)
             schemaFolders.forEach(item => {
                 const schemaDir = migrationsDir + '/' + item
-
                 if (self.isDir(schemaDir) && item === schemaName) {
                     const id = tDate
                     const changelogPath = schemaDir + '/changelog/' + item + '.xml'
@@ -145,7 +154,7 @@ module.exports = class {
                         version
                     )
 
-                    const ret = self.updateChangelog(typeOfMigration, changelogPath, changesetName, username, id)
+                    const ret = self.updateChangelog(typeOfMigration, changelogPath, changesetName, username, id, typeOfObject)
                     returnVal.push(ret, changesetName)
                 }
             })

--- a/lib/generateChangeSetforOracleDB.js
+++ b/lib/generateChangeSetforOracleDB.js
@@ -121,10 +121,11 @@ function ask() {
                             for (let i = 0; i < dbChange.length; i++) {
                                 const retVal = generate.execute(
                                     answers.typeOfMigration.toString(),
-                                    answers.schemaname,
+                                    answers.schemaname.toString(),
                                     answers.username,
                                     dbChange[i],
-                                    answers.migrationsDir
+                                    answers.migrationsDir,
+                                    answers.typeOfObject.toLowerCase()
                                 )
                                 if (retVal[0]) {
                                     console.log('File ' + retVal[1] + ' was created successfully\n')
@@ -153,10 +154,11 @@ function ask() {
                                 answers.typeOfObject.toLowerCase()
                             const retVal = generate.execute(
                                 answers.typeOfMigration.toString(),
-                                answers.schemaname,
+                                answers.schemaname.toString(),
                                 answers.username,
                                 dbChange,
-                                answers.migrationsDir
+                                answers.migrationsDir,
+                                answers.typeOfObject.toLowerCase()
                             )
                             if (retVal[0]) {
                                 console.log(


### PR DESCRIPTION
During the workshop with SPI, we found that in the changelog, splitStatements=false should only be added for packages.

Also, 
   the linter caused some issues with data type of the schemaname fetched from inquirer.