### PR TITLE
Use CustomError util-function.childProcess for reject to be compatible for ESLinting with .reject(Error) and still be able to get the exit code from CustomError

### DIFF
--- a/lib/CustomError.js
+++ b/lib/CustomError.js
@@ -1,0 +1,20 @@
+class BasicCustomError extends Error {
+    constructor(data, ...params) {
+        // Pass remaining arguments (including vendor specific ones) to parent constructor
+        super(...params)
+
+        // Maintains proper stack trace for where our error was thrown (only available on V8)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, BasicCustomError)
+        }
+
+        this.name = 'BasicCustomError'
+        // Custom debugging information
+        this.data = data
+        this.date = new Date()
+    }
+}
+
+// Add other CustomeError(s) if needed.
+
+module.exports = { BasicCustomError }

--- a/lib/GitOperation.js
+++ b/lib/GitOperation.js
@@ -62,7 +62,7 @@ module.exports = class GitOp {
                 // if 'credential.helper' has NOT been set, it wil exit with code 1
                 .catch(proc => {
                     // anything other than exit 1 is an unexpected error
-                    if (proc.exitCode !== 1) {
+                    if (proc.data.exitCode !== 1) {
                         return Promise.reject(proc)
                     }
                     return Promise.resolve(true)

--- a/lib/util-functions.js
+++ b/lib/util-functions.js
@@ -1,7 +1,7 @@
-/* eslint prefer-promise-reject-errors: 0 */
 'use strict'
 const { spawn } = require('child_process')
 const { ENV } = require('./constants')
+const { BasicCustomError } = require('./CustomError')
 
 function previousEnv(env) {
     const stage = {
@@ -27,17 +27,17 @@ async function childProcess(...args) {
 
         cp.on('close', exitCode => {
             if (exitCode === 0) {
-                return resolve({ stdout, stderr, exitCode })
+                resolve({ stdout, stderr, exitCode })
             } else {
                 // console.error("ChildProcess: " + args + ".\nOn close with non-zero exist code: " + exitCode);
-                reject({ stdout, stderr, exitCode })
+                reject(new BasicCustomError({ stdout, stderr, exitCode }, `Error encountered for command! (${args})`))
             }
         })
         cp.on('exit', exitCode => {
             if (exitCode === 0) {
                 return resolve({ stdout, stderr, exitCode })
             } else {
-                reject({ stdout, stderr, exitCode })
+                reject(new BasicCustomError({ stdout, stderr, exitCode }, `Error encountered for command! (${args})`))
             }
         })
 


### PR DESCRIPTION
Use CustomError util-function.childProcess for reject to be compatible for ESLinting with .reject(Error) and still be able to get the exit code from CustomError